### PR TITLE
Improve cards on organiser page

### DIFF
--- a/about/organisers/index-en.md
+++ b/about/organisers/index-en.md
@@ -64,7 +64,7 @@ lang: en
         margin: auto;
         display: block;
         color: #3c3c3c;
-        height: 120px;
+        height: 140px;
     }
     .card .card-img-wrapper {
         position: relative;

--- a/about/organisers/index-en.md
+++ b/about/organisers/index-en.md
@@ -24,6 +24,11 @@ lang: en
         border-top-left-radius: 5px;
         border-top-right-radius: 5px;
     }
+    .cards {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-evenly;
+    }
     .card {
         position: relative;
         display: inline-block;
@@ -111,7 +116,7 @@ BuildingBloCS 2023 is led by a set of ~~charismatic~~ passionate overall ICs who
 aim to help make BuildingBloCS 2023 even bigger and more far-reaching than ever before.
 
 
-<section>
+<section class="cards">
     {% for organiser in site.data.oics %}
 
     <div class="card">
@@ -149,7 +154,7 @@ aim to help make BuildingBloCS 2023 even bigger and more far-reaching than ever 
 
 Without our organizers, we wouldn't be able to organize much of BuildingBloCS, hence this serves as a _thank-you note_ to all of them for their willingness to help and make BuildingBloCS possible!
 
-<section>
+<section class="cards">
     {% for organiser in site.data.organisers %}
 
     <div class="card">


### PR DESCRIPTION
No GitHub issue or notion task was raised. Please inform me if you require one.

There were three original issues:
1. Cards on the organiser page were left-aligned
2. Cards did not space evenly
3. Certain cards were too short for the description

This PR contains a short fix to turn the section with cards into a flexbox container, and increasing the card description height to 140px from 120px;

---

## Checklist

- [x] Have you checked for **grammar** errors?
- [x] Have you checked for **spelling** errors?

---

## Screenshots (if any)

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Screenshot 2023-03-09 at 2 12 57 PM](https://user-images.githubusercontent.com/24543395/223935938-29329a45-0314-4818-8ca2-0acf85b5a500.png) | ![Screenshot 2023-03-09 at 2 13 45 PM](https://user-images.githubusercontent.com/24543395/223936092-9626eac7-deee-473b-b274-fb881d237ac1.png) |
| ![Screenshot 2023-03-09 at 2 15 07 PM](https://user-images.githubusercontent.com/24543395/223936317-b54e018f-58ff-4ff5-a238-0a72d4b9db94.png) | ![Screenshot 2023-03-09 at 2 15 25 PM](https://user-images.githubusercontent.com/24543395/223936385-a40019f7-5fe8-4fae-86a9-7a2e15205877.png) |
| ![Screenshot 2023-03-09 at 2 16 44 PM](https://user-images.githubusercontent.com/24543395/223936579-424fe8dc-c5fe-4982-98d4-c7e0c425feb7.png) | ![Screenshot 2023-03-09 at 2 16 02 PM](https://user-images.githubusercontent.com/24543395/223936467-6ca37a3a-48d4-4f05-8667-c8a70fb19c40.png) |

---

## Additional Information

Nil
